### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Using Gnu parallel, you can run multiple processes asynchronously, with differen
 
 e.g. Send 1000 lines at a time to 10 simultaneous jobs.
 
-cat hathifile.txt | parallel -n1000 -j10 python3 generator.py >jsoncatalog.txt
+cat hathifile.txt | parallel --pipe -n1000 -j10 python3 generator.py >jsoncatalog.txt

--- a/generator.py
+++ b/generator.py
@@ -96,7 +96,7 @@ def main():
     results = querySolr(volids, solr)
     for result in results:
         htfile_record = records[result['id']]
-        record = build_record(results, htfile_record)
+        record = build_record(result['id'],results, htfile_record)
         args.outfile.write(json.dumps(record)+'\n')
 
     logging.info("done")


### PR DESCRIPTION
One change to the documentation (must use parallel with --pipe) and one to the code (the `build_record` function seems to take three inputs).
